### PR TITLE
Insert Likes into Tweets and Comments

### DIFF
--- a/accounts/api/serializers.py
+++ b/accounts/api/serializers.py
@@ -22,6 +22,10 @@ class UserSerializerForComment(UserSerializerForTweet):
     pass
 
 
+class UserSerializerForLike(UserSerializerForTweet):
+    pass
+
+
 class SignupSerializer(serializers.ModelSerializer):
     username = serializers.CharField(max_length=20, min_length=6)
     password = serializers.CharField(max_length=20, min_length=6)

--- a/comments/api/serializers.py
+++ b/comments/api/serializers.py
@@ -3,10 +3,13 @@ from comments.models import Comment
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from tweets.models import Tweet
+from likes.services import LikeService
 
 
 class CommentSerializer(serializers.ModelSerializer):
     user = UserSerializerForComment()
+    likes_count = serializers.SerializerMethodField()
+    has_liked = serializers.SerializerMethodField()
 
     class Meta:
         model = Comment
@@ -17,7 +20,15 @@ class CommentSerializer(serializers.ModelSerializer):
             'content',
             'created_at',
             'updated_at',
+            'likes_count',
+            'has_liked',
         )
+
+    def get_likes_count(self, obj):
+        return obj.like_set.count()
+
+    def get_has_liked(self, obj):
+        return LikeService.has_liked(self.context['request'].user, obj)
 
 
 class CommentSerializerForCreate(serializers.ModelSerializer):
@@ -51,5 +62,3 @@ class CommentSerializerForUpdate(serializers.ModelSerializer):
         instance.content = validated_data['content']
         instance.save()
         return instance
-
-

--- a/comments/api/tests.py
+++ b/comments/api/tests.py
@@ -6,18 +6,16 @@ from django.utils import timezone
 
 COMMENT_URL = '/api/comments/'
 COMMENT_DETAIL_URL = '/api/comments/{}/'
+TWEET_LIST_API = '/api/tweets/'
+TWEET_DETAIL_API = '/api/tweets/{}/'
+NEWSFEED_LIST_API = '/api/newsfeeds/'
 
 
 class CommentApiTests(TestCase):
 
     def setUp(self):
-        self.pluto = self.create_user('pluto')
-        self.pluto_client = APIClient()
-        self.pluto_client.force_authenticate(self.pluto)
-        self.brunch = self.create_user('brunch')
-        self.brunch_client = APIClient()
-        self.brunch_client.force_authenticate(self.brunch)
-
+        self.pluto, self.pluto_client = self.create_user_and_client('pluto')
+        self.brunch, self.brunch_client = self.create_user_and_client('brunch')
         self.tweet = self.create_tweet(self.pluto)
 
     def test_list(self):
@@ -123,6 +121,27 @@ class CommentApiTests(TestCase):
         self.assertEqual(comment.created_at, before_created_at)
         self.assertNotEqual(comment.created_at, now)
         self.assertNotEqual(comment.updated_at, before_updated_at)
+
+    def test_comments_count(self):
+        # test tweet detail api
+        tweet = self.create_tweet(self.pluto)
+        url = TWEET_DETAIL_API.format(tweet.id)
+        response = self.brunch_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['comments_count'], 0)
+
+        # test tweet list api
+        self.create_comment(self.pluto, tweet)
+        response = self.brunch_client.get(TWEET_LIST_API, {'user_id': self.pluto.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['tweets'][0]['comments_count'], 1)
+
+        # test newsfeed list api
+        self.create_comment(self.brunch, tweet)
+        self.create_newsfeed(self.brunch, tweet)
+        response = self.brunch_client.get(NEWSFEED_LIST_API)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['newsfeeds'][0]['tweet']['comments_count'], 2)
 
 
 

--- a/comments/api/views.py
+++ b/comments/api/views.py
@@ -36,7 +36,11 @@ class CommentViewSet(viewsets.GenericViewSet):
         comments = self.filter_queryset(queryset)\
             .prefetch_related('user')\
             .order_by('created_at')
-        serializer = CommentSerializer(comments, many=True)
+        serializer = CommentSerializer(
+            comments,
+            context={'request': request},
+            many=True,
+        )
         return Response(
             {'comments': serializer.data},
             status=status.HTTP_200_OK,
@@ -57,7 +61,7 @@ class CommentViewSet(viewsets.GenericViewSet):
 
         comment = serializer.save()
         return Response(
-            CommentSerializer(comment).data,
+            CommentSerializer(comment, context={'request': request}).data,
             status=status.HTTP_201_CREATED,
         )
 
@@ -75,7 +79,7 @@ class CommentViewSet(viewsets.GenericViewSet):
             }, status=status.HTTP_400_BAD_REQUEST)
         updated_comment = serializer.save()
         return Response(
-            CommentSerializer(updated_comment).data,
+            CommentSerializer(updated_comment, context={'request': request}).data,
             status=status.HTTP_200_OK,
         )
 

--- a/likes/api/serializers.py
+++ b/likes/api/serializers.py
@@ -1,4 +1,4 @@
-from accounts.api.serializers import UserSerializer
+from accounts.api.serializers import UserSerializerForLike
 from comments.models import Comment
 from django.contrib.contenttypes.models import ContentType
 from likes.models import Like
@@ -8,7 +8,7 @@ from tweets.models import Tweet
 
 
 class LikeSerializer(serializers.ModelSerializer):
-    user = UserSerializer()
+    user = UserSerializerForLike()
 
     class Meta:
         model = Like

--- a/likes/api/tests.py
+++ b/likes/api/tests.py
@@ -1,8 +1,13 @@
 from testing.testcases import TestCase
+from rest_framework.test import APIClient
 
 
 LIKE_BASE_URL = '/api/likes/'
 LIKE_CANCEL_URL = '/api/likes/cancel/'
+COMMENT_LIST_API = '/api/comments/'
+TWEET_LIST_API = '/api/tweets/'
+TWEET_DETAIL_API = '/api/tweets/{}/'
+NEWSFEED_LIST_API = '/api/newsfeeds/'
 
 
 class LikeApiTests(TestCase):
@@ -152,3 +157,69 @@ class LikeApiTests(TestCase):
         self.assertEqual(response.data['deleted'], 1)
         self.assertEqual(tweet.like_set.count(), 0)
         self.assertEqual(comment.like_set.count(), 0)
+
+    def test_likes_in_comments_api(self):
+        tweet = self.create_tweet(self.pluto)
+        comment = self.create_comment(self.pluto, tweet)
+
+        # test anonymous client
+        anonymous_client = APIClient()
+        response = anonymous_client.get(COMMENT_LIST_API, {'tweet_id': tweet.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['comments'][0]['has_liked'], False)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 0)
+
+        # test comments list api
+        response = self.brunch_client.get(COMMENT_LIST_API, {'tweet_id': tweet.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['comments'][0]['has_liked'], False)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 0)
+        self.create_like(self.brunch, comment)
+        response = self.brunch_client.get(COMMENT_LIST_API, {'tweet_id': tweet.id})
+        self.assertEqual(response.data['comments'][0]['has_liked'], True)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 1)
+
+        # test tweet detail api
+        self.create_like(self.pluto, comment)
+        url = TWEET_DETAIL_API.format(tweet.id)
+        response = self.brunch_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['comments'][0]['has_liked'], True)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 2)
+
+    def test_likes_in_tweets_api(self):
+        tweet = self.create_tweet(self.pluto)
+
+        # test tweet detail api
+        url = TWEET_DETAIL_API.format(tweet.id)
+        response = self.brunch_client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['has_liked'], False)
+        self.assertEqual(response.data['likes_count'], 0)
+        self.create_like(self.brunch, tweet)
+        response = self.brunch_client.get(url)
+        self.assertEqual(response.data['has_liked'], True)
+        self.assertEqual(response.data['likes_count'], 1)
+
+        # test tweets list api
+        response = self.brunch_client.get(TWEET_LIST_API, {'user_id': self.pluto.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['tweets'][0]['has_liked'], True)
+        self.assertEqual(response.data['tweets'][0]['likes_count'], 1)
+
+        # test newsfeed list api
+        self.create_like(self.pluto, tweet)
+        self.create_newsfeed(self.brunch, tweet)
+        response = self.brunch_client.get(NEWSFEED_LIST_API)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['newsfeeds'][0]['tweet']['has_liked'], True)
+        self.assertEqual(response.data['newsfeeds'][0]['tweet']['likes_count'], 2)
+
+        # test likes details
+        url = TWEET_DETAIL_API.format(tweet.id)
+        response = self.brunch_client.get(url)
+        self.assertEqual(len(response.data['likes']), 2)
+        self.assertEqual(response.data['likes'][0]['user']['id'], self.pluto.id)
+        self.assertEqual(response.data['likes'][1]['user']['id'], self.brunch.id)
+

--- a/likes/services.py
+++ b/likes/services.py
@@ -1,0 +1,15 @@
+from likes.models import Like
+from django.contrib.contenttypes.models import ContentType
+
+
+class LikeService(object):
+
+    @classmethod
+    def has_liked(cls, user, target):
+        if user.is_anonymous:
+            return False
+        return Like.objects.filter(
+            content_type=ContentType.objects.get_for_model(target.__class__),
+            object_id=target.id,
+            user=user,
+        ).exists()

--- a/newsfeeds/api/views.py
+++ b/newsfeeds/api/views.py
@@ -15,7 +15,11 @@ class NewsFeedViewSet(viewsets.GenericViewSet):
         return NewsFeed.objects.filter(user=self.request.user)
 
     def list(self, request):
-        serializer = NewsFeedSerializer(self.get_queryset(), many=True)
+        serializer = NewsFeedSerializer(
+            self.get_queryset(),
+            context={'request': request},
+            many=True,
+        )
         return Response({
             'newsfeeds': serializer.data,
         }, status=status.HTTP_200_OK)

--- a/testing/testcases.py
+++ b/testing/testcases.py
@@ -2,6 +2,7 @@ from django.test import TestCase as DjangoTestCase
 from django.contrib.auth.models import User
 from tweets.models import Tweet
 from comments.models import Comment
+from newsfeeds.models import NewsFeed
 from likes.models import Like
 from rest_framework.test import APIClient
 from django.contrib.contenttypes.models import ContentType
@@ -52,3 +53,6 @@ class TestCase(DjangoTestCase):
         client = APIClient()
         client.force_authenticate(user)
         return user, client
+
+    def create_newsfeed(self, user, tweet):
+        return NewsFeed.objects.create(user=user, tweet=tweet)

--- a/tweets/api/serializers.py
+++ b/tweets/api/serializers.py
@@ -2,35 +2,76 @@ from rest_framework import serializers
 from tweets.models import Tweet
 from accounts.api.serializers import UserSerializerForTweet
 from comments.api.serializers import CommentSerializer
+from likes.services import LikeService
+from likes.api.serializers import LikeSerializer
 
 
 class TweetSerializer(serializers.ModelSerializer):
     user = UserSerializerForTweet()
+    comments_count = serializers.SerializerMethodField()
+    likes_count = serializers.SerializerMethodField()
+    has_liked = serializers.SerializerMethodField()
 
     class Meta:
         model = Tweet
-        fields = ('id', 'user', 'created_at', 'content')
+        fields = (
+            'id',
+            'user',
+            'created_at',
+            'content',
+            'comments_count',
+            'likes_count',
+            'has_liked',
+        )
+
+    def get_comments_count(self, obj):
+        return obj.comment_set.count()
+
+    def get_likes_count(self, obj):
+        return obj.like_set.count()
+
+    def get_has_liked(self, obj):
+        return LikeService.has_liked(self.context['request'].user, obj)
 
 
-class TweetSerializerWithComments(TweetSerializer):
-    # To get comments of a certain tweet, there are multiple ways,
-    # except claimed 'source=comments__set' like below,
-    # we can also
-    # 1. add a method in Tweet model like:
-    # @property
-    # def comments(self):
-    #     return self.comment_set.all()
-    # or
-    # 2. use serializers.SerializerMethodField
-    # comments = serializers.SerializerMethodField()
-    # def get_comments(self, obj): # here obj is tweet
-    #     return CommentSerializer(obj.comment_set.all(), many=True).data
+# class TweetSerializerWithComments(TweetSerializer):
+#     # To get comments of a certain tweet, there are multiple ways,
+#     # except claimed 'source=comments__set' like below,
+#     # we can also
+#     # 1. add a method in Tweet model like:
+#     # @property
+#     # def comments(self):
+#     #     return self.comment_set.all()
+#     # or
+#     # 2. use serializers.SerializerMethodField
+#     # comments = serializers.SerializerMethodField()
+#     # def get_comments(self, obj): # here obj is tweet
+#     #     return CommentSerializer(obj.comment_set.all(), many=True).data
+#
+#     comments = CommentSerializer(source='comment_set', many=True)
+#
+#     class Meta:
+#         model = Tweet
+#         fields = ('id', 'user', 'created_at', 'content', 'comments')
 
-    comments = CommentSerializer(source='comment_set', many=True)
+
+class TweetSerializerForDetail(TweetSerializer):
+    comments =  CommentSerializer(source='comment_set', many=True)
+    likes = LikeSerializer(source='like_set', many=True)
 
     class Meta:
         model = Tweet
-        fields = ('id', 'user', 'created_at', 'content', 'comments')
+        fields = (
+            'id',
+            'user',
+            'created_at',
+            'content',
+            'likes',
+            'comments',
+            'likes_count',
+            'comments_count',
+            'has_liked',
+        )
 
 
 class TweetSerializerForCreate(serializers.ModelSerializer):
@@ -45,8 +86,3 @@ class TweetSerializerForCreate(serializers.ModelSerializer):
         content = validated_data['content']
         tweet = Tweet.objects.create(user=user, content=content)
         return tweet
-
-
-
-
-


### PR DESCRIPTION
1 Add comments_count(), likes_count(), has_liked() methods in TweetSerializer and CommentSerializer, express these attributes in Tweet list() and Comment list(); Change TweetSerializerWithComments to TweetSerializerForDetail, which means likes are successfully inserted into Tweet and Comment API
2 Cause Newsfeed Serializer adopted TweetSerializer(), likes are also inserted into Newfeed API
3 Add create_newsfeed() method in testcases in testing model
4 Conduct responding unit tests in likes api tests and comment api tests