### PR TITLE
Push tweets in Redis cache

### DIFF
--- a/testing/testcases.py
+++ b/testing/testcases.py
@@ -7,11 +7,13 @@ from likes.models import Like
 from rest_framework.test import APIClient
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import caches
+from utils.redis_client import RedisClient
 
 
 class TestCase(DjangoTestCase):
 
     def clear_cache(self):
+        RedisClient.clear()
         caches['testing'].clear()
 
     @property

--- a/tweets/api/views.py
+++ b/tweets/api/views.py
@@ -10,6 +10,7 @@ from tweets.models import Tweet
 from newsfeeds.services import NewsFeedService
 from utils.decorators import required_params
 from utils.paginations import EndlessPagination
+from tweets.services import TweetService
 
 
 class TweetViewSet(viewsets.GenericViewSet):
@@ -25,7 +26,7 @@ class TweetViewSet(viewsets.GenericViewSet):
     @required_params(params=['user_id'])
     def list(self, request):
         user_id = request.query_params['user_id']
-        tweets = Tweet.objects.filter(user_id=user_id).order_by('-created_at')
+        tweets = TweetService.get_cached_tweets(user_id=user_id)
         tweets = self.paginate_queryset(tweets)
         serializer = TweetSerializer(
             tweets,

--- a/tweets/listeners.py
+++ b/tweets/listeners.py
@@ -1,0 +1,6 @@
+def push_tweet_to_cache(sender, instance, created, **kwargs):
+    if not created:
+        return
+
+    from tweets.services import TweetService
+    TweetService.push_tweet_to_cache(instance)

--- a/tweets/models.py
+++ b/tweets/models.py
@@ -5,6 +5,9 @@ from utils.time_helpers import utc_now
 from django.contrib.contenttypes.models import ContentType
 from tweets.constants import TweetPhotoStatus, TWEET_PHOTO_STATUS_CHOICES
 from utils.memcached_helper import MemcachedHelper
+from django.db.models.signals import post_save, pre_delete
+from tweets.listeners import push_tweet_to_cache
+from utils.listeners import invalidate_object_cache
 
 
 class Tweet(models.Model):
@@ -75,6 +78,11 @@ class TweetPhoto(models.Model):
 
     def __str__(self):
         return f'{self.tweet_id}: {self.file}'
+
+
+post_save.connect(invalidate_object_cache, sender=Tweet)
+pre_delete.connect(invalidate_object_cache, sender=Tweet)
+post_save.connect(push_tweet_to_cache, sender=Tweet)
 
 
 

--- a/tweets/services.py
+++ b/tweets/services.py
@@ -1,4 +1,6 @@
-from tweets.models import TweetPhoto
+from tweets.models import TweetPhoto, Tweet
+from twitter.cache import USER_TWEETS_PATTERN
+from utils.redis_helper import RedisHelper
 
 
 class TweetService(object):
@@ -15,3 +17,16 @@ class TweetService(object):
             )
             photos.append(photo)
         TweetPhoto.objects.bulk_create(photos)
+
+    @classmethod
+    def get_cached_tweets(cls, user_id):
+        queryset = Tweet.objects.filter(user_id=user_id).order_by('-created_at')
+        key = USER_TWEETS_PATTERN.format(user_id=user_id)
+        return RedisHelper.download_objects_from_cache(key, queryset)
+
+    @classmethod
+    def push_tweet_to_cache(cls, tweet):
+        queryset = Tweet.objects.filter(user_id=tweet.user_id).order_by('-created_at')
+        key = USER_TWEETS_PATTERN.format(user_id=tweet.user_id)
+        RedisHelper.push_object(key, tweet, queryset)
+

--- a/tweets/tests.py
+++ b/tweets/tests.py
@@ -5,6 +5,8 @@ from tweets.models import TweetPhoto
 from tweets.constants import TweetPhotoStatus
 from utils.redis_client import RedisClient
 from utils.redis_serializers import DjangoModelSerializer
+from tweets.services import TweetService
+from twitter.cache import USER_TWEETS_PATTERN
 
 
 # Create your tests here.
@@ -13,13 +15,13 @@ class TweetTests(TestCase):
     def setUp(self):
         self.clear_cache()
         self.pluto = self.create_user('pluto')
-        self.tweet = self.create_tweet(self.pluto, content = 'We want PEACE, NO WAR!')
+        self.tweet = self.create_tweet(self.pluto, content='We want PEACE, NO WAR!')
 
     def test_hours_to_now(self):
         self.tweet.created_at = utc_now() - timedelta(hours=10)
         self.tweet.save()
         self.assertEqual(self.tweet.hours_to_now, 10)
-        
+
     def test_like_set(self):
         self.create_like(self.pluto, self.tweet)
         self.assertEqual(self.tweet.like_set.count(), 1)
@@ -53,3 +55,53 @@ class TweetTests(TestCase):
         data = conn.get(f'tweet:{tweet.id}')
         cached_tweet = DjangoModelSerializer.deserialize(data)
         self.assertEqual(tweet, cached_tweet)
+
+
+class TweetServiceTests(TestCase):
+
+    def setUp(self):
+        self.clear_cache()
+        self.pluto = self.create_user('pluto')
+
+    def test_get_user_tweets(self):
+        tweet_ids = []
+        for i in range(3):
+            tweet = self.create_tweet(self.pluto, 'Meow {}'.format(i))
+            tweet_ids.append(tweet.id)
+        tweet_ids = tweet_ids[::-1]
+
+        RedisClient.clear()
+        conn = RedisClient.get_connection()
+
+        # cache miss
+        tweets = TweetService.get_cached_tweets(self.pluto.id)
+        self.assertEqual([t.id for t in tweets], tweet_ids)
+
+        # cache updated
+        new_tweet = self.create_tweet(self.pluto, 'Meow meow')
+        tweets = TweetService.get_cached_tweets(self.pluto.id)
+        tweet_ids.insert(0, new_tweet.id)
+        self.assertEqual([t.id for t in tweets], tweet_ids)
+
+    def test_create_new_tweet_before_get_cached_tweets(self):
+        tweet1 = self.create_tweet(self.pluto, 'tweet1')
+
+        RedisClient.clear()
+        conn = RedisClient.get_connection()
+
+        key = USER_TWEETS_PATTERN.format(user_id=self.pluto.id)
+        self.assertEqual(conn.exists(key), False)
+        tweet2 = self.create_tweet(self.pluto, 'tweet2')
+        self.assertEqual(conn.exists(key), True)
+
+        tweets = TweetService.get_cached_tweets(self.pluto.id)
+        self.assertEqual([t.id for t in tweets], [tweet2.id, tweet1.id])
+
+
+
+
+
+
+
+
+

--- a/twitter/cache.py
+++ b/twitter/cache.py
@@ -1,3 +1,6 @@
 # memcached
 FOLLOWINGS_PATTERN = 'followings:{user_id}'
 USER_PROFILE_PATTERN = 'userprofile:{user_id}'
+
+# redis
+USER_TWEETS_PATTERN = 'user_tweets:{user_id}'

--- a/utils/paginations.py
+++ b/utils/paginations.py
@@ -1,5 +1,6 @@
 from rest_framework.pagination import BasePagination
 from rest_framework.response import Response
+from dateutil import parser
 
 
 class EndlessPagination(BasePagination):
@@ -12,7 +13,34 @@ class EndlessPagination(BasePagination):
     def to_html(self):
         pass
 
+    def paginate_ordered_list(self, reverse_ordered_list, request):
+        if 'created_at__gt' in request.query_params:
+            created_at__gt = parser.isoparse(request.query_params['created_at__gt'])
+            objects = []
+            for obj in reverse_ordered_list:
+                if obj.created_at > created_at__gt:
+                    objects.append(obj)
+                else:
+                    break
+            self.has_next_page = False
+            return objects
+
+        index = 0
+        if 'created_at__lt' in request.query_params:
+            created_at__lt = parser.isoparse(request.query_params['created_at__lt'])
+            for index, obj in enumerate(reverse_ordered_list):
+                if obj.created_at < created_at__lt:
+                    break
+            else:
+                reverse_ordered_list = []
+
+        self.has_next_page = len(reverse_ordered_list) > index + self.page_size
+        return reverse_ordered_list[index: index + self.page_size]
+
     def paginate_queryset(self, queryset, request, view=None):
+        if type(queryset) == list:
+            return self.paginate_ordered_list(queryset, request)
+
         if 'created_at__gt' in request.query_params:
             # created_at__gt is for loading the newest information/data
             # by pull-to-refresh

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -5,7 +5,7 @@ from utils.redis_client import RedisClient
 class UtilsTestS(TestCase):
 
     def setUp(self):
-        RedisClient.clear()
+        self.clear_cache()
 
     def test_redis_client(self):
         conn = RedisClient.get_connection()


### PR DESCRIPTION
1 To use Redis as a cache to store users' tweets, add RedisHelper class, which includes download_objects_from_cache(), 
_upload_objects_to_cache() and push_objects() these three functions
2 To mplemente endless pagination on cached tweets, add paginate_ordered_list() in EndlessPagination class
3 Add listeners in tweets.models
4 Conduct the corresponding unit tests in tweets.tests