### PR TITLE
cache likes count and comments count in Redis

### DIFF
--- a/comments/listeners.py
+++ b/comments/listeners.py
@@ -1,4 +1,4 @@
-from utils.listeners import invalidate_object_cache
+from utils.redis_helper import RedisHelper
 
 
 def incr_comments_count(sender, instance, created, **kwargs):
@@ -10,7 +10,7 @@ def incr_comments_count(sender, instance, created, **kwargs):
 
     Tweet.objects.filter(id=instance.tweet_id)\
         .update(comments_count=F('comments_count') + 1)
-    invalidate_object_cache(sender=Tweet, instance=instance.tweet)
+    RedisHelper.incr_count(instance.tweet, 'comments_count')
 
 
 def decr_comments_count(sender, instance, **kwargs):
@@ -19,4 +19,4 @@ def decr_comments_count(sender, instance, **kwargs):
 
     Tweet.objects.filter(id=instance.tweet_id) \
         .update(comments_count=F('comments_count') - 1)
-    invalidate_object_cache(sender=Tweet, instance=instance.tweet)
+    RedisHelper.decr_count(instance.tweet, 'comments_count')

--- a/likes/listeners.py
+++ b/likes/listeners.py
@@ -1,3 +1,6 @@
+from utils.redis_helper import RedisHelper
+
+
 def incr_likes_count(sender, instance, created, **kwargs):
     from tweets.models import Tweet
     from django.db.models import F
@@ -13,11 +16,8 @@ def incr_likes_count(sender, instance, created, **kwargs):
     # using F function generate an SQL expression at database level
     # https://docs.djangoproject.com/en/4.0/ref/models/expressions/#f-expressions
     Tweet.objects.filter(id=instance.object_id).update(likes_count=F('likes_count') + 1)
-
-    # Way 2: can trigger listeners
-    # tweet = instance.content_object
-    # tweet.likes_count = F('likes_count') + 1
-    # tweet.save()
+    tweet = instance.content_object
+    RedisHelper.incr_count(tweet, 'likes_count')
 
 
 def decr_likes_count(sender, instance, **kwargs):
@@ -29,3 +29,5 @@ def decr_likes_count(sender, instance, **kwargs):
         return
 
     Tweet.objects.filter(id=instance.object_id).update(likes_count=F('likes_count') - 1)
+    tweet = instance.content_object
+    RedisHelper.decr_count(tweet, 'likes_count')

--- a/tweets/api/serializers.py
+++ b/tweets/api/serializers.py
@@ -7,6 +7,7 @@ from comments.api.serializers import CommentSerializer
 from likes.services import LikeService
 from likes.api.serializers import LikeSerializer
 from tweets.constants import TWEET_PHOTOS_UPLOAD_LIMIT
+from utils.redis_helper import RedisHelper
 
 
 class TweetSerializer(serializers.ModelSerializer):
@@ -30,10 +31,10 @@ class TweetSerializer(serializers.ModelSerializer):
         )
 
     def get_comments_count(self, obj):
-        return obj.comment_set.count()
+        return RedisHelper.get_count(obj, 'comments_count')
 
     def get_likes_count(self, obj):
-        return obj.like_set.count()
+        return RedisHelper.get_count(obj, 'likes_count')
 
     def get_has_liked(self, obj):
         return LikeService.has_liked(self.context['request'].user, obj)

--- a/utils/redis_helper.py
+++ b/utils/redis_helper.py
@@ -49,3 +49,45 @@ class RedisHelper:
         serialized_data = DjangoModelSerializer.serialize(obj)
         conn.lpush(key, serialized_data)
         conn.ltrim(key, 0, settings.REDIS_LIST_LENGTH_LIMIT - 1)
+
+    @classmethod
+    def get_count_key(cls, obj, attr):
+        return '{}.{}:{}'.format(obj.__class__.__name__, attr, obj.id)
+
+    @classmethod
+    def incr_count(cls, obj, attr):
+        conn = RedisClient.get_connection()
+        key = cls.get_count_key(obj, attr)
+        if conn.exists(key):
+            return conn.incr(key)
+
+        obj.refresh_from_db()
+        conn.set(key, getattr(obj, attr))
+        conn.expire(key, settings.REDIS_KEY_EXPIRE_TIME)
+        return getattr(obj, attr)
+
+
+    @classmethod
+    def decr_count(cls, obj, attr):
+        conn = RedisClient.get_connection()
+        key = cls.get_count_key(obj, attr)
+        if conn.exists(key):
+            return conn.decr(key)
+
+        obj.refresh_from_db()
+        conn.set(key, getattr(obj, attr))
+        conn.expire(key, settings.REDIS_KEY_EXPIRE_TIME)
+        return getattr(obj, attr)
+
+
+    @classmethod
+    def get_count(cls, obj, attr):
+        conn = RedisClient.get_connection()
+        key = cls.get_count_key(obj, attr)
+        count = conn.get(key)
+        if count is not None:
+            return int(count)
+        obj.refresh_from_db()
+        count = getattr(obj, attr)
+        conn.set(key, count)
+        return count


### PR DESCRIPTION
1 Cache likes count and comments count in Redis, add incr_count() and decr_count() and get_count() in RedisHelper , altered the data resource in get_likes_count() and get_comments_count() in tweets serializers, from SQL to Redis
2 Conduct the corresponding unit tests