### PR TITLE
Asynchronously batch fanout newsfeeds

### DIFF
--- a/friendships/models.py
+++ b/friendships/models.py
@@ -29,13 +29,13 @@ class Friendship(models.Model):
         index_together = (
             # get all users that this account are following
             ('following_user_id', 'created_at'),
-            # get all users that being followed this account
+            # get all users that followed this account
             ('followed_user_id', 'created_at'),
         )
         unique_together = (('following_user_id', 'followed_user_id'),)
 
     def __str__(self):
-        return '{} is following {}.'.format(self.following_user, self.followed_user)
+        return '{} followed {}.'.format(self.following_user, self.followed_user)
 
     @property
     def cached_following_user(self):

--- a/friendships/services.py
+++ b/friendships/services.py
@@ -40,6 +40,11 @@ class FriendshipService(object):
         return [friendship.following_user for friendship in friendships]
 
     @classmethod
+    def get_follower_ids(cls, followed_user_id):
+        friendships = Friendship.objects.filter(followed_user_id=followed_user_id)
+        return [friendship.following_user_id for friendship in friendships]
+
+    @classmethod
     def get_following_user_id_set(cls, following_user_id):
         key = FOLLOWINGS_PATTERN.format(user_id=following_user_id)
         user_id_set = cache.get(key)

--- a/newsfeeds/api/views.py
+++ b/newsfeeds/api/views.py
@@ -10,6 +10,9 @@ class NewsFeedViewSet(viewsets.GenericViewSet):
     permission_classes = [IsAuthenticated]
     pagination_class = EndlessPagination
 
+    def get_queryset(self):
+        return NewsFeed.objects.filter(user=self.request.user)
+
     def list(self, request):
         cached_newsfeeds = NewsFeedService.get_cached_newsfeeds(request.user.id)
         newsfeed_page = self.paginator.paginate_cached_list(cached_newsfeeds, request)

--- a/newsfeeds/constants.py
+++ b/newsfeeds/constants.py
@@ -1,0 +1,3 @@
+from django.conf import settings
+
+FANOUT_BATCH_SIZE = 1000 if not settings.TESTING else 3

--- a/newsfeeds/services.py
+++ b/newsfeeds/services.py
@@ -1,7 +1,7 @@
 from newsfeeds.models import NewsFeed
 from twitter.cache import USER_NEWSFEEDS_PATTERN
 from utils.redis_helper import RedisHelper
-from newsfeeds.tasks import fanout_newsfeeds_task
+from newsfeeds.tasks import fanout_newsfeeds_main_task
 
 
 class NewsFeedService(object):
@@ -17,7 +17,7 @@ class NewsFeedService(object):
         # which can be serialized by celery,
         # i.e., tweet.id is a valid argument, but tweet is not,
         # cause celery doesn't know how to serialize Tweet.
-        fanout_newsfeeds_task.delay(tweet.id)
+        fanout_newsfeeds_main_task.delay(tweet.id, tweet.user_id)
 
     @classmethod
     def get_cached_newsfeeds(cls, user_id):

--- a/newsfeeds/tasks.py
+++ b/newsfeeds/tasks.py
@@ -3,30 +3,42 @@ from newsfeeds.models import NewsFeed
 from tweets.models import Tweet
 from celery import shared_task
 from utils.time_constants import ONE_HOUR
+from newsfeeds.constants import FANOUT_BATCH_SIZE
 
 
-@shared_task(time_limit=ONE_HOUR)
-def fanout_newsfeeds_task(tweet_id):
+@shared_task(routing_key='newsfeeds', time_limit=ONE_HOUR)
+def fanout_newsfeeds_batch_task(tweet_id, follower_ids):
     # to prevent circular dependency, write the import mark below
     from newsfeeds.services import NewsFeedService
-    tweet = Tweet.objects.get(id=tweet_id)
-
-    # incorrect implementation:
-    # put sql operation in for loop
-    # followers = FriendshipService.get_followers(tweet.user)
-    # for follower in followers:
-    #     NewsFeed.objects.create(user=follower, tweet=tweet)
-
-    # correct implementation:
-    # using bulk_create()
     newsfeeds = [
-        NewsFeed(user=follower, tweet=tweet) for
-        follower in FriendshipService.get_followers(tweet.user)
+        NewsFeed(user_id=follower_id, tweet_id=tweet_id)
+        for follower_id in follower_ids
     ]
-    newsfeeds.append(NewsFeed(user=tweet.user, tweet=tweet))
     NewsFeed.objects.bulk_create(newsfeeds)
 
     # bulk_create() cannot trigger post_save signal,
     # that's why we need push newsfeeds one by one into cache manually
     for newsfeed in newsfeeds:
         NewsFeedService.push_newsfeed_to_cache(newsfeed)
+
+    return '{} newsfeeds have been created.'.format(len(newsfeeds))
+
+
+@shared_task(routing_key='default', time_limit=ONE_HOUR)
+def fanout_newsfeeds_main_task(tweet_id, tweet_user_id):
+    # Create a newsfeed to user who posted this tweet in the first place,
+    # make sure user believes the newsfeed has been created successfully in no time
+    NewsFeed.objects.create(user_id=tweet_user_id, tweet_id=tweet_id)
+
+    # obtain all the followers' ids, then break down into a butch of batch_size sets
+    follower_ids = FriendshipService.get_follower_ids(tweet_user_id)
+    index = 0
+    while index < len(follower_ids):
+        batch_ids = follower_ids[index: index + FANOUT_BATCH_SIZE]
+        fanout_newsfeeds_batch_task.delay(tweet_id, batch_ids)
+        index += FANOUT_BATCH_SIZE
+
+    return '{} newsfeeds are going to fanout, {} batches are created.'.format(
+        len(follower_ids),
+        (len(follower_ids) - 1) // FANOUT_BATCH_SIZE + 1,
+    )

--- a/twitter/settings.py
+++ b/twitter/settings.py
@@ -11,6 +11,8 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 
 from pathlib import Path
+from kombu import Queue
+
 import sys
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -23,7 +25,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = '&y*q2$%c)f57#iu3cm!3^gj)6s(e=e17^&p)$jdv=)yjb*6eez'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False #True
+DEBUG = True
 
 ALLOWED_HOSTS = ['127.0.0.1', '192.168.33.10', 'localhost']
 
@@ -182,6 +184,10 @@ REDIS_LIST_LENGTH_LIMIT = 1000 if not TESTING else 20
 CELERY_BROKER_URL = 'redis://127.0.0.1:6379/2' if not TESTING else 'redis://127.0.0.1:6379/0'
 CELERY_TIMEZONE = 'UTC'
 CELERY_TASK_ALWAYS_EAGER = TESTING
+CELERY_QUEUES = (
+    Queue('default', routing_key='default'),
+    Queue('newsfeeds', routing_key='newsfeeds'),
+)
 
 try:
     from .local_settings import *


### PR DESCRIPTION
1 For users who have tremendously large fan base, the newsfeeds fanout procedure might last long and give a compromised user experience, to deal with that case, the fanout procedure could be implemented distributedly.
2 Breaking the follower set into batches, then create an asynchronou main fanout task to implement the sub tasks batch by batch.
3 Conduct the corresponding unit tests.