### PR TITLE
add rate limiter on multiple operations

### DIFF
--- a/accounts/api/views.py
+++ b/accounts/api/views.py
@@ -19,6 +19,9 @@ from accounts.api.serializers import (
 )
 
 from utils.permissions import IsObjectOwner
+from django.utils.decorators import method_decorator
+from ratelimit.decorators import ratelimit
+
 
 
 class UserViewSet(viewsets.ReadOnlyModelViewSet):
@@ -35,6 +38,7 @@ class AccountViewSet(viewsets.ViewSet):
     serializer_class = SignupSerializer
 
     @action(methods=['POST'], detail=False)
+    @method_decorator(ratelimit(key='ip', rate='3/s', method='POST', block=True))
     def signup(self, request):
         """
         Using username, email, password to SIGN IN
@@ -55,6 +59,7 @@ class AccountViewSet(viewsets.ViewSet):
         }, status=201)
 
     @action(methods=['POST'], detail=False)
+    @method_decorator(ratelimit(key='ip', rate='3/s', method='POST', block=True))
     def login(self, request):
         """
         Get username and password from request,
@@ -94,6 +99,7 @@ class AccountViewSet(viewsets.ViewSet):
         })
 
     @action(methods=['GET'], detail=False)
+    @method_decorator(ratelimit(key='ip', rate='3/s', method='GET', block=True))
     def login_status(self, request):
         """
         check the current status and details of the user
@@ -107,6 +113,7 @@ class AccountViewSet(viewsets.ViewSet):
         return Response(data)
 
     @action(methods=['POST'], detail=False)
+    @method_decorator(ratelimit(key='ip', rate='3/s', method='POST', block=True))
     def logout(self, request):
         django_logout(request)
         return Response({'success': True})

--- a/comments/api/views.py
+++ b/comments/api/views.py
@@ -10,6 +10,8 @@ from comments.api.serializers import (
 )
 from utils.decorators import required_params
 from inbox.services import NotificationService
+from django.utils.decorators import method_decorator
+from ratelimit.decorators import ratelimit
 
 
 class CommentViewSet(viewsets.GenericViewSet):
@@ -25,6 +27,7 @@ class CommentViewSet(viewsets.GenericViewSet):
         return [AllowAny()]
 
     @required_params(params=['tweet_id'])
+    @method_decorator(ratelimit(key='user', rate='3/s', method='GET', block=True))
     def list(self, request, *args, **kwargs):
         """
         the usual way:
@@ -47,6 +50,7 @@ class CommentViewSet(viewsets.GenericViewSet):
             status=status.HTTP_200_OK,
         )
 
+    @method_decorator(ratelimit(key='user', rate='3/s', method='POST', block=True))
     def create(self, request, *args, **kwargs):
         data = {
             'user_id': request.user.id,
@@ -67,6 +71,7 @@ class CommentViewSet(viewsets.GenericViewSet):
             status=status.HTTP_201_CREATED,
         )
 
+    @method_decorator(ratelimit(key='user', rate='3/s', method='POST', block=True))
     def update(self, request, *args, **kwargs):
         # get_object() is provided by DRF, it would raise 404 error
         # when object does not exist.
@@ -85,6 +90,7 @@ class CommentViewSet(viewsets.GenericViewSet):
             status=status.HTTP_200_OK,
         )
 
+    @method_decorator(ratelimit(key='user', rate='5/s', method='POST', block=True))
     def destroy(self, request, *args, **kwargs):
         comment = self.get_object()
         comment.delete()

--- a/likes/api/views.py
+++ b/likes/api/views.py
@@ -10,6 +10,8 @@ from likes.api.serializers import (
     LikeSerializerForCreate,
     LikeSerializerForCancel,
 )
+from django.utils.decorators import method_decorator
+from ratelimit.decorators import ratelimit
 
 
 class LikeViewSet(viewsets.GenericViewSet):
@@ -18,6 +20,7 @@ class LikeViewSet(viewsets.GenericViewSet):
     serializer_class = LikeSerializerForCreate
 
     @required_params(method='POST', params=['content_type', 'object_id'])
+    @method_decorator(ratelimit(key='user', rate='10/s', method='POST', block=True))
     def create(self, request, *args, **kwargs):
         serializer = LikeSerializerForCreate(
             data=request.data,
@@ -38,6 +41,7 @@ class LikeViewSet(viewsets.GenericViewSet):
 
     @required_params(method='POST', params=['content_type', 'object_id'])
     @action(methods=['POST'], detail=False)
+    @method_decorator(ratelimit(key='user', rate='10/s', method='POST', block=True))
     def cancel(self, request, *args, **kwargs):
         serializer = LikeSerializerForCancel(
             data=request.data,

--- a/newsfeeds/api/views.py
+++ b/newsfeeds/api/views.py
@@ -4,6 +4,8 @@ from newsfeeds.models import NewsFeed
 from newsfeeds.services import NewsFeedService
 from newsfeeds.api.serializers import NewsFeedSerializer
 from utils.paginations import EndlessPagination
+from django.utils.decorators import method_decorator
+from ratelimit.decorators import ratelimit
 
 
 class NewsFeedViewSet(viewsets.GenericViewSet):
@@ -13,6 +15,7 @@ class NewsFeedViewSet(viewsets.GenericViewSet):
     def get_queryset(self):
         return NewsFeed.objects.filter(user=self.request.user)
 
+    @method_decorator(ratelimit(key='user', rate='5/s', method='GET', block=True))
     def list(self, request):
         cached_newsfeeds = NewsFeedService.get_cached_newsfeeds(request.user.id)
         newsfeed_page = self.paginator.paginate_cached_list(cached_newsfeeds, request)

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ django-debug-toolbar==3.2.4
 django-filter==21.1
 django-model-utils==4.2.0
 django-notifications-hq==1.7.0
+django-ratelimit==3.0.1
 django-storages==1.12.3
 djangorestframework==3.12.2
 httplib2==0.9.2

--- a/twitter/settings.py
+++ b/twitter/settings.py
@@ -64,6 +64,7 @@ REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': [
         'django_filters.rest_framework.DjangoFilterBackend',
     ],
+    'EXCEPTION_HANDLER': 'utils.ratelimit.exception_handler',
 }
 
 MIDDLEWARE = [
@@ -171,6 +172,12 @@ CACHES = {
         'TIMEOUT': 86400,
         'KEY_PREFIX': 'testing',
     },
+    'ratelimit': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': '127.0.0.1:11211',
+        'TIMEOUT': 86400 * 7,
+        'KEY_PREFIX': 'rl',
+    }
 }
 
 # Redis
@@ -188,6 +195,12 @@ CELERY_QUEUES = (
     Queue('default', routing_key='default'),
     Queue('newsfeeds', routing_key='newsfeeds'),
 )
+
+# Rate Limiter
+RATELIMIT_USE_CACHE = 'ratelimit'
+# RATELIMIT_CACHE_PREFIX = 'rl' # the prefix has already set in CACHES
+RATELIMIT_ENABLE = not TESTING
+
 
 try:
     from .local_settings import *

--- a/utils/ratelimit.py
+++ b/utils/ratelimit.py
@@ -1,0 +1,15 @@
+from rest_framework.views import exception_handler as drf_exception_handler
+from ratelimit.exceptions import Ratelimited
+
+
+def exception_handler(exc, context):
+    # calling REST framework's default exception handler first,
+    # get the standard error response
+    response = drf_exception_handler(exc, context)
+
+    # then add the wanted HTTP status code to the response
+    if isinstance(exc, Ratelimited):
+        response.data['detail'] = 'Too many requests, try again later.'
+        response.status_code = 429
+
+    return response


### PR DESCRIPTION
As the title indicates, introducing the third party plugin 'django-ratelimit' to add rate limiter on multiple actions, preventing too frequently access to SQL or cache, which might lest network traffic jam