### PR TITLE
add gatekeeper to hbase friendship and update friendship serializer

### DIFF
--- a/accounts/services.py
+++ b/accounts/services.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import caches
 from twitter.cache import USER_PROFILE_PATTERN
+from utils.memcached_helper import MemcachedHelper
 
 cache = caches['testing'] if settings.TESTING else caches['default']
 
@@ -26,4 +27,12 @@ class UserService:
     def invalidate_profile(cls, user_id):
         key = USER_PROFILE_PATTERN.format(user_id=user_id)
         cache.delete(key)
+
+    @classmethod
+    def get_user_by_id(cls, user_id):
+        return MemcachedHelper.get_object_through_cache(User, user_id)
+
+    @classmethod
+    def get_profile_through_cache(cls, user_id):
+        key = USER_PROFILE_PATTERN.format(user_id=user_id)
 

--- a/friendships/api/serializers.py
+++ b/friendships/api/serializers.py
@@ -4,12 +4,24 @@ from friendships.models import Friendship
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from friendships.services import FriendshipService
+from accounts.services import UserService
 
 
-class FollowingUserIdSetMixin:
+class BaseFriendshipSerializer(serializers.Serializer):
+    user = serializers.SerializerMethodField()
+    created_at = serializers.SerializerMethodField()
+    has_followed = serializers.SerializerMethodField()
 
-    @property
-    def following_user_id_set(self: serializers.ModelSerializer):
+    def update(self, instance, validated_data):
+        pass
+
+    def create(self, validated_data):
+        pass
+
+    def get_user_id(self, obj):
+        raise NotImplementedError
+
+    def _get_following_user_id_set(self):
         if self.context['request'].user.is_anonymous:
             return {}
         if hasattr(self, '_cached_following_user_id_set'):
@@ -20,33 +32,25 @@ class FollowingUserIdSetMixin:
         setattr(self, '_cached_following_user_id_set', user_id_set)
         return user_id_set
 
-
-class FollowerSerializer(serializers.ModelSerializer, FollowingUserIdSetMixin):
-    # To get this account's all followers, it belongs to following friendship,
-    # other users are 'following' me
-    user = UserSerializerForFriendship(source='cached_following_user')
-    has_followed = serializers.SerializerMethodField()
-
-    class Meta:
-        model = Friendship
-        fields = ('user', 'created_at', 'has_followed')
-
     def get_has_followed(self, obj):
-        return obj.following_user_id in self.following_user_id_set
+        return self.get_user_id(obj) in self._get_following_user_id_set()
+
+    def get_user(self, obj):
+        user = UserService.get_user_by_id(self.get_user_id(obj))
+        return UserSerializerForFriendship(user).data
+
+    def get_created_at(self, obj):
+        return obj.created_at
 
 
-class FollowingSerializer(serializers.ModelSerializer, FollowingUserIdSetMixin):
-    # To get all user to which this account is following, it belongs to followed friendship,
-    # other users are 'followed' by me
-    user = UserSerializerForFriendship(source='cached_followed_user')
-    has_followed = serializers.SerializerMethodField()
+class FollowerSerializer(BaseFriendshipSerializer):
+    def get_user_id(self, obj):
+        return obj.following_user_id
 
-    class Meta:
-        model = Friendship
-        fields = ('user', 'created_at', 'has_followed')
 
-    def get_has_followed(self, obj):
-        return obj.followed_user_id in self.following_user_id_set
+class FollowingSerializer(BaseFriendshipSerializer):
+    def get_user_id(self, obj):
+        return obj.followed_user_id
 
 
 class FriendshipSerializerForCreate(serializers.ModelSerializer):
@@ -76,8 +80,9 @@ class FriendshipSerializerForCreate(serializers.ModelSerializer):
         return attrs
 
     def create(self, validated_data):
-        return Friendship.objects.create(
-            following_user_id=validated_data['following_user_id'],
-            followed_user_id=validated_data['followed_user_id'],
+        following_user_id = validated_data['following_user_id'],
+        followed_user_id = validated_data['followed_user_id'],
+        return FriendshipService.follow(
+            following_user_id=following_user_id,
+            followed_user_id=followed_user_id,
         )
-

--- a/friendships/services.py
+++ b/friendships/services.py
@@ -2,6 +2,10 @@ from friendships.models import Friendship
 from django.conf import settings
 from django.core.cache import caches
 from twitter.cache import FOLLOWINGS_PATTERN
+from friendships.hbase_models import HBaseFollower, HBaseFollowing
+from gatekeeper.models import GateKeeper
+
+import time
 
 cache = caches['testing'] if settings.TESTING else caches['default']
 
@@ -63,3 +67,42 @@ class FriendshipService(object):
     def invalidate_following_cache(cls, from_user_id):
         key = FOLLOWINGS_PATTERN.format(user_id=from_user_id)
         cache.delete(key)
+
+    @classmethod
+    def follow(cls, following_user_id, followed_user_id):
+        if following_user_id == followed_user_id:
+            return None
+
+        if not GateKeeper.is_switch_on('switch_friendship_to_hbase'):
+            # create data in mysql
+            return Friendship.objects.create(
+                following_user_id=following_user_id,
+                followed_user_id=followed_user_id,
+            )
+
+        # create data in hbase
+        now = int(time.time() * 1000000)
+        HBaseFollower.create(
+            following_user_id=following_user_id,
+            followed_user_id=followed_user_id,
+            created_at=now,
+        )
+        return HBaseFollowing.create(
+            following_user_id=following_user_id,
+            followed_user_id=followed_user_id,
+            created_at=now,
+        )
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/gatekeeper/models.py
+++ b/gatekeeper/models.py
@@ -1,0 +1,31 @@
+from utils.redis_client import  RedisClient
+
+
+class GateKeeper(object):
+
+    @classmethod
+    def get(cls, gk_name):
+        conn = RedisClient.get_connection()
+        name = f'gatekeeper:{gk_name}'
+        if not conn.exists(name):
+            return {'percent': 0, 'description': ''}
+
+        redis_hash = conn.hgetall(name)
+        return {
+            'percent': int(redis_hash.get(b'percent', 0)),
+            'description': str(redis_hash.get(b'description', '')),
+        }
+
+    @classmethod
+    def set_kv(cls, gk_name, key, value):
+        conn = RedisClient.get_connection()
+        name = f'gatekeeper:{gk_name}'
+        conn.hset(name, key, value)
+
+    @classmethod
+    def is_switch_on(cls, gk_name):
+        return cls.get(gk_name)['percent'] == 100
+
+    @classmethod
+    def in_gk(cls, gk_name, user_id):
+        return user_id % 100 < cls.get(gk_name)['percent']

--- a/gatekeeper/tests.py
+++ b/gatekeeper/tests.py
@@ -1,0 +1,22 @@
+from testing.testcases import TestCase
+from gatekeeper.models import GateKeeper
+
+
+class GateKeeperTests(TestCase):
+
+    def setUp(self):
+        self.clear_cache()
+
+    def test_gatekeeper(self):
+        gk = GateKeeper.get('gk_name')
+        self.assertEqual(gk, {'percent': 0, 'description': ''})
+        self.assertEqual(GateKeeper.is_switch_on('gk_name'), False)
+        self.assertEqual(GateKeeper.in_gk('gk_name', 1), False)
+
+        GateKeeper.set_kv('gk_name', 'percent', 20)
+        self.assertEqual(GateKeeper.is_switch_on('gk_name'), False)
+        self.assertEqual(GateKeeper.in_gk('gk_name', 1), True)
+
+        GateKeeper.set_kv('gk_name', 'percent', 100)
+        self.assertEqual(GateKeeper.is_switch_on('gk_name'), True)
+        self.assertEqual(GateKeeper.in_gk('gk_name', 1), True)

--- a/utils/redis_helper.py
+++ b/utils/redis_helper.py
@@ -13,7 +13,7 @@ class RedisHelper:
 
         # cache REDIS_LIST_LENGTH_LIMIT data records at most,
         # exceeds this size, to require data from database directly
-        for obj in objects[:settings.REDIS_LIST_LENGTH_LIMIT]:
+        for obj in objects:
             serialized_data = DjangoModelSerializer.serialize(obj)
             serialized_list.append(serialized_data)
 
@@ -23,6 +23,7 @@ class RedisHelper:
 
     @classmethod
     def download_objects_from_cache(cls, key, queryset):
+        queryset = queryset[:settings.REDIS_LIST_LENGTH_LIMIT]
         conn = RedisClient.get_connection()
 
         if conn.exists(key):
@@ -41,6 +42,7 @@ class RedisHelper:
 
     @classmethod
     def push_object(cls, key, obj, queryset):
+        queryset = queryset[:settings.REDIS_LIST_LENGTH_LIMIT]
         conn = RedisClient.get_connection()
         if not conn.exists(key):
             cls._upload_objects_to_cache(key, queryset)
@@ -66,7 +68,6 @@ class RedisHelper:
         conn.expire(key, settings.REDIS_KEY_EXPIRE_TIME)
         return getattr(obj, attr)
 
-
     @classmethod
     def decr_count(cls, obj, attr):
         conn = RedisClient.get_connection()
@@ -78,7 +79,6 @@ class RedisHelper:
         conn.set(key, getattr(obj, attr))
         conn.expire(key, settings.REDIS_KEY_EXPIRE_TIME)
         return getattr(obj, attr)
-
 
     @classmethod
     def get_count(cls, obj, attr):


### PR DESCRIPTION
1 Add gatekeeper class, which enables to decide what percentage of friendship relations in hbase, and conduct the corresponding unit tests on gatekeepers
2 Adjust the friendship serializers to work together with gatekeeper